### PR TITLE
fix: resolve ivy-settings dependency issue

### DIFF
--- a/solr5.x/ivy/ivy-settings.xml
+++ b/solr5.x/ivy/ivy-settings.xml
@@ -1,7 +1,16 @@
 
 <ivysettings>
-    <settings defaultResolver="central"/>
+    <settings defaultResolver="my-chain"/>
     <resolvers>
-        <ibiblio name="central" m2compatible="true"/>
+        <chain name="my-chain">
+                <ibiblio name="restlet" m2compatible="true" root="http://maven.restlet.com"/>
+                <ibiblio name="central" m2compatible="true"/>
+        </chain>
     </resolvers>
+    <modules>
+        <module organization="org.restlet.jee" resolver="restlet"/>
+        <module organization="restlet" resolver="restlet"/>
+        <module organization="org.restlet" resolver="restlet"/>
+    </modules>
+
 </ivysettings>


### PR DESCRIPTION
I found the same issue as described by this user (although he references another one of your repositories the issue is the same)

http://stackoverflow.com/questions/30630227/java-ivy-maven-build-dependency-resolution-for-lucidworks-auto-phrase-tokenizer

This PR resolves the dependency issue and allows the build to complete.
